### PR TITLE
Adding a flag to disable downloading as files.

### DIFF
--- a/appviewx/common.go
+++ b/appviewx/common.go
@@ -218,7 +218,7 @@ func GetDownloadPassword(resourceData *schema.ResourceData, downloadFormat strin
 	return "", true
 }
 
-func downloadCertificateFromAppviewx(appviewxResourceId, commonName, serialNumber, downloadFormat, downloadPassword, downloadPath string, isChainRequired bool, appviewxSessionID, appviewxAccessToken string, configAppViewXEnvironment *config.AppViewXEnvironment) bool {
+func downloadCertificateFromAppviewx(appviewxResourceId, commonName, serialNumber, downloadFormat, downloadPassword, downloadPath string, isChainRequired, writeToFile bool, appviewxSessionID, appviewxAccessToken string, configAppViewXEnvironment *config.AppViewXEnvironment) (string, bool) {
 	httpMethod := config.HTTPMethodPost
 	appviewxEnvironmentIP := configAppViewXEnvironment.AppViewXEnvironmentIP
 	appviewxEnvironmentPort := configAppViewXEnvironment.AppViewXEnvironmentPort
@@ -229,7 +229,7 @@ func downloadCertificateFromAppviewx(appviewxResourceId, commonName, serialNumbe
 	requestBody, err := json.Marshal(payload)
 	if err != nil {
 		log.Println("[ERROR] error in Marshalling the payload ", payload, err)
-		return false
+		return "", false
 	}
 	client := &http.Client{Transport: HTTPTransport()}
 
@@ -238,7 +238,7 @@ func downloadCertificateFromAppviewx(appviewxResourceId, commonName, serialNumbe
 	req, err := http.NewRequest(httpMethod, url, bytes.NewBuffer(requestBody))
 	if err != nil {
 		log.Println("[ERROR] error in creating new Request", err)
-		return false
+		return "", false
 	}
 
 	for key, value := range headers {
@@ -254,7 +254,7 @@ func downloadCertificateFromAppviewx(appviewxResourceId, commonName, serialNumbe
 	httpResponse, err := client.Do(req)
 	if err != nil {
 		log.Println("[ERROR] error in http request", err)
-		return false
+		return "", false
 	} else {
 		log.Println("[INFO] Request for downloading the certificate submitted successfully")
 	}
@@ -263,21 +263,26 @@ func downloadCertificateFromAppviewx(appviewxResourceId, commonName, serialNumbe
 		responseBody, err := io.ReadAll(httpResponse.Body)
 		if err == nil {
 			log.Println("[ERROR] Response obtained : ", string(responseBody))
-			return false
+			return "", false
 		}
 	}
 	responseByte, err := io.ReadAll(httpResponse.Body)
 	if err != nil {
 		log.Println("[ERROR] ", err)
-		return false
+		return "", false
 	} else {
-		err = os.WriteFile(downloadPath, responseByte, 0777)
-		if err != nil {
-			log.Println("[ERROR] Error while downloading the certificate file content in ", downloadPath, " due to : ", err)
-			return false
+		if writeToFile {
+			err = os.WriteFile(downloadPath, responseByte, 0777)
+			if err != nil {
+				log.Println("[ERROR] Error while downloading the certificate file content in ", downloadPath, " due to : ", err)
+				return "", false
+			} else {
+				log.Println("[INFO] Downloaded certificate file and available in ", downloadPath)
+				return string(responseByte), true
+			}
 		} else {
-			log.Println("[INFO] Downloaded certificate file and available in ", downloadPath)
-			return true
+			log.Println("[INFO] Retrieved certificate content into state")
+			return string(responseByte), true
 		}
 	}
 
@@ -291,6 +296,17 @@ func downloadKey(resourceData *schema.ResourceData, resourceID, appviewxSessionI
 	downloadPassword := getPasswordWithPriority(providerKeyPassword, resourceKeyPassword)
 	downloadPasswordProtectedKey := resourceData.Get(constants.DOWNLOAD_PASSWORD_PROTECTED_KEY).(bool)
 
+	var writeToFile bool = true
+	if v, ok := resourceData.GetOkExists("download_to_file"); ok {
+		writeToFile = v.(bool)
+	} else {
+		// fallback if GetOkExists doesn't work for boolean default
+		val := resourceData.Get("download_to_file")
+		if val != nil {
+			writeToFile = val.(bool)
+		}
+	}
+
 	if downloadPassword == "" {
 		log.Println("[ERROR] Password not found for private key download")
 		return errors.New("[ERROR] Password not found for private key download")
@@ -303,17 +319,20 @@ func downloadKey(resourceData *schema.ResourceData, resourceID, appviewxSessionI
 	}
 	uuid := searchResponse.AppviewxResponse.ResponseObject.Objects[0].UUID
 	log.Println("[INFO] UUID for the resource id " + resourceID + " was obtained successfully")
-	if downloadSuccess := downloadKeyFromAppviewx(uuid, downloadPassword, downloadPath, downloadPasswordProtectedKey, appviewxSessionID, accessToken, configAppViewXEnvironment); downloadSuccess {
-		log.Println("[INFO] Private key downloaded successfully in the specified path")
+	if keyContent, downloadSuccess := downloadKeyFromAppviewx(uuid, downloadPassword, downloadPath, downloadPasswordProtectedKey, writeToFile, appviewxSessionID, accessToken, configAppViewXEnvironment); downloadSuccess {
+		log.Println("[INFO] Private key downloaded successfully")
 		resourceData.SetId(strconv.Itoa(rand.Int()))
+		if !writeToFile {
+			resourceData.Set("private_key", keyContent)
+		}
 	} else {
-		log.Println("[ERROR] Private key was not downloaded in the specified path")
-		return errors.New("[ERROR] Private key was not downloaded in the specified path")
+		log.Println("[ERROR] Private key was not downloaded")
+		return errors.New("[ERROR] Private key was not downloaded")
 	}
 	return nil
 }
 
-func downloadKeyFromAppviewx(uuid, downloadPassword, downloadPath string, downloadPasswordProtectedKey bool, appviewxSessionID, appviewxAccessToken string, configAppViewXEnvironment *config.AppViewXEnvironment) bool {
+func downloadKeyFromAppviewx(uuid, downloadPassword, downloadPath string, downloadPasswordProtectedKey, writeToFile bool, appviewxSessionID, appviewxAccessToken string, configAppViewXEnvironment *config.AppViewXEnvironment) (string, bool) {
 	httpMethod := config.HTTPMethodPost
 	var response config.AppviewxDownloadKeyResponse
 	var responseByte []byte
@@ -326,7 +345,7 @@ func downloadKeyFromAppviewx(uuid, downloadPassword, downloadPath string, downlo
 	requestBody, err := json.Marshal(payload)
 	if err != nil {
 		log.Println("[ERROR] error in Marshalling the payload ", payload, err)
-		return false
+		return "", false
 	}
 	client := &http.Client{Transport: HTTPTransport()}
 
@@ -335,7 +354,7 @@ func downloadKeyFromAppviewx(uuid, downloadPassword, downloadPath string, downlo
 	req, err := http.NewRequest(httpMethod, url, bytes.NewBuffer(requestBody))
 	if err != nil {
 		log.Println("[ERROR] error in creating new Request", err)
-		return false
+		return "", false
 	}
 
 	for key, value := range headers {
@@ -351,7 +370,7 @@ func downloadKeyFromAppviewx(uuid, downloadPassword, downloadPath string, downlo
 	httpResponse, err := client.Do(req)
 	if err != nil {
 		log.Println("[ERROR] error in http request", err)
-		return false
+		return "", false
 	} else {
 		log.Println("[INFO] Request for downloading the private submitted successfully")
 	}
@@ -360,35 +379,38 @@ func downloadKeyFromAppviewx(uuid, downloadPassword, downloadPath string, downlo
 		responseBody, err := io.ReadAll(httpResponse.Body)
 		if err == nil {
 			log.Println("[ERROR] Response obtained : ", string(responseBody))
-			return false
+			return "", false
 		}
 	}
 	if responseByte, err = io.ReadAll(httpResponse.Body); err != nil {
 		log.Println("[ERROR] Error while obtaining the response due to : ", err)
-		return false
+		return "", false
 	}
 	if err = json.Unmarshal(responseByte, &response); err != nil {
 		log.Println("[ERROR] Error while obtaining the response due to : ", err)
-		return false
+		return "", false
 	} else if response.AppviewxResponse.Status == "Success" {
 		if downloadPasswordProtectedKey {
 			log.Println("[INFO] Downloading the password protected private key file content. Kindly use the password provided in the .tf file")
-			if err := writeKeyToFile(downloadPath, []byte(response.AppviewxResponse.PrivateKey)); err != nil {
-				return false
+			if res, err := writeKeyToFile(downloadPath, []byte(response.AppviewxResponse.PrivateKey), writeToFile); err != nil {
+				return "", false
+			} else {
+				return res, true
 			}
 		} else {
-			if err := decryptPasswordProtectedKeyAndDownloadKey(response.AppviewxResponse.PrivateKey, downloadPassword, downloadPath); err != nil {
-				return false
+			if res, err := decryptPasswordProtectedKeyAndDownloadKey(response.AppviewxResponse.PrivateKey, downloadPassword, downloadPath, writeToFile); err != nil {
+				return "", false
+			} else {
+				return res, true
 			}
 		}
 	} else {
 		log.Println("[ERROR] Error while obtaining the response due to : ", err)
-		return false
+		return "", false
 	}
-	return true
 }
 
-func decryptPasswordProtectedKeyAndDownloadKey(encryptedPrivateKey, password string, downloadPath string) error {
+func decryptPasswordProtectedKeyAndDownloadKey(encryptedPrivateKey, password string, downloadPath string, writeToFile bool) (string, error) {
 	log.Println("[INFO] Decrypting the password protected private key file content")
 	tempFile := filepath.Join(os.TempDir(), "temp_private_key.pem")
 	var file *os.File
@@ -396,34 +418,50 @@ func decryptPasswordProtectedKeyAndDownloadKey(encryptedPrivateKey, password str
 	file, err = os.Create(tempFile)
 	if err != nil {
 		fmt.Println("Error creating temp file:", err)
-		return errors.New("error while decrypting the private key file content")
+		return "", errors.New("error while decrypting the private key file content")
 	}
-	defer file.Close()
 	defer os.Remove(tempFile)
 
 	_, err = file.WriteString(encryptedPrivateKey)
+	file.Close()
 	if err != nil {
 		fmt.Println("Error writing to file:", err)
-		return errors.New("error while decrypting the private key file content")
+		return "", errors.New("error while decrypting the private key file content")
 	}
-	cmd := exec.Command("openssl", "pkey", "-in", tempFile, "-out", downloadPath, "-passin", "pass:"+password)
+	cmd := exec.Command("openssl", "pkey", "-in", tempFile, "-passin", "pass:"+password)
 
-	err = cmd.Run()
+	out, err := cmd.Output()
 	if err != nil {
 		log.Printf("[ERROR] Error executing OpenSSL command: %v\n", err)
-		return errors.New("error while decrypting the private key file content")
+		return "", errors.New("error while decrypting the private key file content")
 	}
-	log.Println("[INFO] Private key decrypted successfully and saved in the specified path")
-	return nil
+
+	if writeToFile {
+		err = os.WriteFile(downloadPath, out, 0600)
+		if err != nil {
+			log.Printf("[ERROR] Error writing decrypted key to file: %v\n", err)
+			return "", errors.New("error writing decrypted key to file")
+		}
+		log.Println("[INFO] Private key decrypted successfully and saved in the specified path")
+	} else {
+		log.Println("[INFO] Private key decrypted successfully and saved in state")
+	}
+
+	return string(out), nil
 }
 
-func writeKeyToFile(downloadPath string, fileContent []byte) error {
-	if err := os.WriteFile(downloadPath, fileContent, 0777); err != nil {
-		log.Println("[ERROR] Error while downloading the private key file content in ", downloadPath, " due to : ", err)
-		return errors.New("[ERROR] Error while downloading the private key file content in " + downloadPath + " due to : " + err.Error())
+func writeKeyToFile(downloadPath string, fileContent []byte, writeToFile bool) (string, error) {
+	if writeToFile {
+		if err := os.WriteFile(downloadPath, fileContent, 0777); err != nil {
+			log.Println("[ERROR] Error while downloading the private key file content in ", downloadPath, " due to : ", err)
+			return "", errors.New("[ERROR] Error while downloading the private key file content in " + downloadPath + " due to : " + err.Error())
+		} else {
+			log.Println("[INFO] Downloaded private key file and available in ", downloadPath)
+			return string(fileContent), nil
+		}
 	} else {
-		log.Println("[INFO] Downloaded private key file and available in ", downloadPath)
-		return nil
+		log.Println("[INFO] Retrieved private key content into state")
+		return string(fileContent), nil
 	}
 }
 

--- a/appviewx/resource_certificate.go
+++ b/appviewx/resource_certificate.go
@@ -125,6 +125,20 @@ func ResourceCertificateServer() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"download_to_file": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"certificate": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"private_key": &schema.Schema{
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceCertificateImport,
@@ -238,12 +252,25 @@ func downloadCertificate(resourceData *schema.ResourceData, resourceID string, a
 	}
 	isChainRequired = resourceData.Get(constants.CERTIFICATE_CHAIN_REQUIRED).(bool)
 
-	if downloadSuccess := downloadCertificateFromAppviewx(resourceID, "", "", downloadFormat, downloadPassword, downloadPath, isChainRequired, appviewxSessionID, accessToken, configAppViewXEnvironment); downloadSuccess {
-		log.Println("[INFO] Certificate downloaded successfully in the specified path")
-		resourceData.SetId(strconv.Itoa(rand.Int()))
+	var writeToFile bool = true
+	if v, ok := resourceData.GetOkExists("download_to_file"); ok {
+		writeToFile = v.(bool)
 	} else {
-		log.Println("[ERROR] Certificate was not downloaded in the specified path")
-		return errors.New("[ERROR] Certificate was not downloaded in the specified path")
+		val := resourceData.Get("download_to_file")
+		if val != nil {
+			writeToFile = val.(bool)
+		}
+	}
+
+	if certContent, downloadSuccess := downloadCertificateFromAppviewx(resourceID, "", "", downloadFormat, downloadPassword, downloadPath, isChainRequired, writeToFile, appviewxSessionID, accessToken, configAppViewXEnvironment); downloadSuccess {
+		log.Println("[INFO] Certificate downloaded successfully")
+		resourceData.SetId(strconv.Itoa(rand.Int()))
+		if !writeToFile {
+			resourceData.Set("certificate", certContent)
+		}
+	} else {
+		log.Println("[ERROR] Certificate was not downloaded")
+		return errors.New("[ERROR] Certificate was not downloaded")
 	}
 	return nil
 }

--- a/appviewx/resource_create_push_certificate_request_status.go
+++ b/appviewx/resource_create_push_certificate_request_status.go
@@ -2023,7 +2023,7 @@ func downloadCertificateIfRequired(resourceId string, d *schema.ResourceData, m 
 	// Get certificate download password if required
 	// certDownloadPassword := d.Get("certificate_download_password").(string)
 	// Download certificate
-	downloadSuccess := downloadCertificateFromAppviewx(
+	_, downloadSuccess := downloadCertificateFromAppviewx(
 		resourceId,
 		certCommonName,
 		"",
@@ -2031,6 +2031,7 @@ func downloadCertificateIfRequired(resourceId string, d *schema.ResourceData, m 
 		"",
 		fullDownloadPath,
 		certificateChainRequired,
+		true,
 		appviewxSessionID,
 		accessToken,
 		configAppViewXEnvironment,

--- a/appviewx/resource_download_certificate.go
+++ b/appviewx/resource_download_certificate.go
@@ -142,7 +142,7 @@ func resourceDownloadCertificate(resourceData *schema.ResourceData, m interface{
 		log.Println("[ERROR] CommonName, SerialNumber or Resource ID details are not available to proceed with certificate download")
 		return errors.New("[ERROR] CommonName, SerialNumber or Resource ID details are not available to proceed with certificate download")
 	}
-	if downloadSuccess := downloadCertificateFromAppviewx(resourceId, commonName, serialNumber, downloadFormat, downloadPassword, downloadPath, isChainRequired, appviewxSessionID, accessToken, configAppViewXEnvironment); downloadSuccess {
+	if _, downloadSuccess := downloadCertificateFromAppviewx(resourceId, commonName, serialNumber, downloadFormat, downloadPassword, downloadPath, isChainRequired, true, appviewxSessionID, accessToken, configAppViewXEnvironment); downloadSuccess {
 		log.Println("[INFO] Certificate downloaded successfully in the specified path")
 		resourceData.SetId(strconv.Itoa(rand.Int()))
 	} else {
@@ -196,7 +196,7 @@ func downloadKeyWithPriority(resourceData *schema.ResourceData, commonName, seri
 	}
 	uuid := searchResponse.AppviewxResponse.ResponseObject.Objects[0].UUID
 	log.Println("[INFO] UUID for the resource id " + resourceID + " was obtained successfully")
-	if downloadSuccess := downloadKeyFromAppviewx(uuid, downloadPassword, downloadPath, downloadPasswordProtectedKey, appviewxSessionID, accessToken, configAppViewXEnvironment); downloadSuccess {
+	if _, downloadSuccess := downloadKeyFromAppviewx(uuid, downloadPassword, downloadPath, downloadPasswordProtectedKey, true, appviewxSessionID, accessToken, configAppViewXEnvironment); downloadSuccess {
 		log.Println("[INFO] Private key downloaded successfully in the specified path")
 		resourceData.SetId(strconv.Itoa(rand.Int()))
 	} else {


### PR DESCRIPTION
We use this provider on terraform agent runners.
Those runners do not have persistent file systems and will not have the files created by this module.

This module should be updated to store these in state without using local files. Flag `download_to_file` created to preserve backward compatibility and defaults to true.